### PR TITLE
Add new Node.js versions to CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x, 20.x, 21.x]
+        node-version: [14.x, 16.x, 18.x, 20.x, 21.x, 22.x, 23.x, 24.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Add testing on Node.js v22, v23, and v24