### PR TITLE
Install all verions in linked mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,12 @@ const install = require('spawn-npm-install')
 const differ = require('ansi-diff-stream')
 const cliSpinners = require('cli-spinners')
 const which = require('which')
+const path = require('path')
+const npa = require('npm-package-arg')
 const argv = require('minimist')(process.argv.slice(2))
 
 const npm5plus = semver.gte(execSync('npm -v', { encoding: 'utf-8' }).trim(), '5.0.0')
+const npm9plus = semver.gte(execSync('npm -v', { encoding: 'utf-8' }).trim(), '9.0.0')
 
 // in case npm ever gets installed as a dependency, make sure we always access
 // it from it's original location
@@ -34,14 +37,15 @@ if (argv.help || argv.h) {
   console.log('Usage: tav [options] [<module> <semver> <command> [args...]]')
   console.log()
   console.log('Options:')
-  console.log('  -h, --help        show this help')
-  console.log('  -v, --version     show the tav version and exit')
-  console.log('  -q, --quiet       don\'t output stdout from tests unless an error occurs')
-  console.log('  --registry=<url>  use a custom registry (e.g. --registry=https://registry.example.com)')
-  console.log('  --verbose         output a lot of information while running')
-  console.log('  --dry-run         do a dry-run (no tests will be executed)')
-  console.log('  --compat          output just module version compatibility - no errors')
-  console.log('  --ci              only run on CI servers when using .tav.yml file')
+  console.log('  -h, --help                        show this help')
+  console.log('  -v, --version                     show the tav version and exit')
+  console.log('  -q, --quiet                       don\'t output stdout from tests unless an error occurs')
+  console.log('  --registry=<url>                  use a custom registry (e.g. --registry=https://registry.example.com)')
+  console.log('  --verbose                         output a lot of information while running')
+  console.log('  --dry-run                         do a dry-run (no tests will be executed)')
+  console.log('  --compat                          output just module version compatibility - no errors')
+  console.log('  --ci                              only run on CI servers when using .tav.yml file')
+  console.log('  --experimental-isolated-installs  install packages into a separate directory and then link them')
   process.exit()
 } else if (argv.version || argv.v) {
   console.log('tav ' + require('./package.json').version)
@@ -270,6 +274,11 @@ function execute (cmd, name, opts, cb) {
 function ensurePackages (packages, registry, cb) {
   log('-- required packages %j', packages)
 
+  if (npm9plus && argv['experimental-isolated-installs']) {
+    attemptIsolatedInstall(packages, registry, cb)
+    return
+  }
+
   if (npm5plus) {
     // npm5 will uninstall everything that's not in the local package.json and
     // not in the install string. This might make tests fail. So if we detect
@@ -333,6 +342,120 @@ function attemptInstall (packages, registry, cb, attempts = 1) {
   })
 
   const opts = { noSave: true, command: npmCmd }
+  if (argv.verbose) opts.stdio = 'inherit'
+  if (argv.registry || registry) opts.registry = argv.registry || registry
+
+  // npm on Travis have a tendency to hang every once in a while
+  // (https://twitter.com/wa7son/status/1006859826549477378). We'll use a
+  // timeout to abort and retry the install in case it hasn't finished within 2
+  // minutes.
+  const timeout = setTimeout(function () {
+    done(new Error('npm install took too long'))
+  }, 2 * 60 * 1000)
+
+  install(packages, opts, done).on('error', done)
+}
+
+const walkUp = function * (p) {
+  for (p = path.resolve(p); p;) {
+    yield p
+    const parent = path.dirname(p)
+    if (parent === p) {
+      break
+    } else {
+      p = parent
+    }
+  }
+}
+function fileExistsSync (path) {
+  try {
+    const stats = fs.statSync(path)
+    return stats.isFile()
+  } catch (_err) {
+    return false
+  }
+}
+function findPackagePathSync (cwd) {
+  for (const p of walkUp(cwd)) {
+    const packagePath = path.resolve(p, 'package.json')
+    const hasPackageJson = fileExistsSync(packagePath)
+    if (hasPackageJson) {
+      return packagePath
+    }
+  }
+  return null
+}
+function attemptIsolatedInstall (packages, registry, cb, attempts = 1) {
+  log('-- installing %j', packages)
+  if (argv['dry-run']) {
+    // Dry-run.
+    setImmediate(cb, 0)
+    return
+  }
+
+  const packagePath = path.dirname(findPackagePathSync(process.cwd()))
+  const installPath = path.join(
+    packagePath,
+    'node_modules',
+    '.tav',
+    packages[packages.length - 1]
+  )
+  /** @type {(err?: Error) => void} */
+  const done = once(function (err) {
+    clearTimeout(timeout)
+
+    if (!err) {
+      for (const pkg of packages) {
+        const parsed = npa(pkg)
+
+        if (parsed.scope) {
+          // ensure the deep scope path exists
+          fs.mkdirSync(path.join(packagePath, 'node_modules', parsed.scope), {
+            recursive: true
+          })
+        }
+
+        fs.rmSync(path.join(packagePath, 'node_modules', parsed.name), {
+          recursive: true,
+          force: true
+        })
+        fs.symlinkSync(
+          path.join(installPath, 'node_modules', parsed.name),
+          path.join(packagePath, 'node_modules', parsed.name)
+        )
+      }
+      return cb()
+    }
+
+    if (++attempts <= 10) {
+      fs.rmSync(installPath, {
+        recursive: true,
+        force: true
+      })
+      console.warn('-- error installing %j (%s) - retrying (%d/10)...', packages, err.message, attempts)
+      attemptIsolatedInstall(packages, registry, cb, attempts)
+    } else {
+      console.error('-- error installing %j - aborting!', packages)
+      console.error(err.stack)
+      cb(err.code || 1)
+    }
+  })
+
+  // create a synthetic package directory
+  fs.mkdirSync(installPath, { recursive: true })
+  fs.writeFileSync(
+    path.join(installPath, 'package.json'),
+    JSON.stringify({ name: 'tav' }, null, 2)
+  )
+
+  // make sure legacy_peer_deps option is unset
+  process.env.npm_config_legacy_peer_deps = undefined
+
+  const opts = {
+    command: npmCmd,
+    'install-strategy': 'linked',
+    cwd: installPath
+  }
   if (argv.verbose) opts.stdio = 'inherit'
   if (argv.registry || registry) opts.registry = argv.registry || registry
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "js-yaml": "^4.1.0",
     "log-symbols": "^4.1.0",
     "minimist": "^1.2.8",
+    "npm-package-arg": "^13.0.0",
     "npm-package-versions": "^2.0.3",
     "once": "^1.4.0",
     "parse-env-string": "^1.0.1",

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ helpOptions.forEach(function (option) {
     })
     processStdout(cp, function (code, lines) {
       t.equal(code, 0, 'should exit with exit code 0')
-      t.equal(lines.length, 11, 'should output 11 lines')
+      t.equal(lines.length, 12, 'should output 12 lines')
       t.ok(lines[0].startsWith('Usage: tav'))
       t.ok(lines[10].startsWith('  --ci')) // TODO: Use .at(-1) once Node.js 14 support is dropped
       t.end()
@@ -33,197 +33,204 @@ helpOptions.forEach(function (option) {
   })
 })
 
-t.test('tests succeed', function (t) {
-  const cp = exec('./index.js roundround "<=0.2.0" -- node -e "process.exit\\(0\\)"')
-  cp.on('close', function (code) {
-    t.equal(code, 0)
-    t.end()
-  })
-  cp.stdout.pipe(process.stdout)
-  cp.stderr.pipe(process.stderr)
-})
+const strategies = ['', '--experimental-isolated-installs']
+strategies.forEach(function (strategy) {
+  t.test(`strategy: ${strategy || 'default'}`, function (t) {
+    t.plan(11)
 
-t.test('tests fail', function (t) {
-  const cp = exec('./index.js roundround "<=0.2.0" -- node -e "process.exit\\(1\\)"')
-  cp.on('close', function (code) {
-    t.equal(code, 1)
-    t.end()
-  })
-  cp.stdout.pipe(process.stdout)
-  cp.stderr.pipe(process.stderr)
-})
-
-t.test('invalid module', function (t) {
-  const cp = exec('./index.js test-all-versions-' + Date.now() + ' ^1.0.0 npm test')
-  cp.on('close', function (code) {
-    t.equal(code, 1)
-    t.end()
-  })
-  cp.stdout.pipe(process.stdout)
-  cp.stderr.pipe(process.stderr)
-})
-
-t.test('yaml', function (t) {
-  const cp = start()
-
-  processStdout(cp, function (code, lines) {
-    t.equal(code, 0)
-    // TODO: Remove tap16 check when Node.js 14 support is dropped
-    t[TAP16 ? 'strictSame' : 'matchOnlyStrict'](lines, [
-      'expire-array@1.1.0: base64-emoji@2.0.0',
-      'expire-array@1.0.0: base64-emoji@2.0.0',
-      'expire-array@1.1.0: base64-emoji@1.0.0',
-      'expire-array@1.0.0: base64-emoji@1.0.0',
-      '//3', // after-all-results@2.0.0, c=3
-      '1/2/', // after-all-results@2.0.0, a=1 b=2
-      '//4', // after-all-results@2.0.0, c=4
-      '1/2/4', // after-all-results@2.0.0, a=1 b=2 c=4
-      '//3', // isobj@1.0.0, c=3
-      '1/2/', // isobj@1.0.0, a=1 b=2
-      'throttling-b', // throttling@1.0.1
-      'throttling-a', // throttling@1.0.2
-      'preinstall', 'pretest', 'b2f-a', 'posttest', 'pretest', 'b2f-b', 'posttest', // b2f@1.0.0
-      '1.0.0', // 27mhz@1.0.1 peerDependency
-      'patterns-a', 'patterns-b', // patterns@1.0.2
-      'patterns-a', 'patterns-b', // patterns@0.0.1
-      'roundround-a', // roundround@0.2.0
-      'roundround-a' // roundround@0.1.0
-    ])
-    t.end()
-  })
-})
-
-t.test('node version', function (t) {
-  const range = '20.x || 21.x'
-  const active = semver.satisfies(process.version, range)
-
-  t.plan(active ? 2 : 1)
-
-  process.chdir('./test/node-version')
-  const cp = start()
-
-  processStdout(cp, function (code, lines) {
-    t.equal(code, 0)
-    lines.forEach(function (line) {
-      if (!active) t.fail('this node version should not produce any output')
-      t.ok(semver.satisfies(line, range))
+    t.test('tests succeed', function (t) {
+      const cp = exec(`./index.js roundround "<=0.2.0" ${strategy} -- node -e "process.exit\\(0\\)"`)
+      cp.on('close', function (code) {
+        t.equal(code, 0)
+        t.end()
+      })
+      cp.stdout.pipe(process.stdout)
+      cp.stderr.pipe(process.stderr)
     })
-  })
-})
 
-t.test('missing "versions" property', function (t) {
-  process.chdir('./test/missing-versions')
-  let found = false
-  const cp = start({ quiet: true })
-  cp.stderr.on('data', function (chunk) {
-    if (!found && /Error: Missing "versions" property for 27mhz/.test(chunk)) {
-      found = true
-    }
-  })
-  cp.on('close', function (code) {
-    t.equal(code, 1)
-    t.ok(found)
-    t.end()
-  })
-})
-
-t.test('array of test cases', function (t) {
-  const expected = ['2.0.1', '2.0.0']
-  t.plan(3)
-
-  process.chdir('./test/array')
-  const cp = start()
-
-  processStdout(cp, function (code, lines) {
-    t.equal(code, 0)
-    lines.forEach(function (line) {
-      t.equal(line, expected.shift())
+    t.test('tests fail', function (t) {
+      const cp = exec(`./index.js roundround "<=0.2.0" ${strategy} -- node -e "process.exit\\(1\\)"`)
+      cp.on('close', function (code) {
+        t.equal(code, 1)
+        t.end()
+      })
+      cp.stdout.pipe(process.stdout)
+      cp.stderr.pipe(process.stderr)
     })
-  })
-})
 
-t.test('no matching versions', function (t) {
-  let stderr = false
+    t.test('invalid module', function (t) {
+      const cp = exec('./index.js test-all-versions-' + Date.now() + ' ^1.0.0 npm test')
+      cp.on('close', function (code) {
+        t.equal(code, 1)
+        t.end()
+      })
+      cp.stdout.pipe(process.stdout)
+      cp.stderr.pipe(process.stderr)
+    })
 
-  process.chdir('./test/no-matching-versions')
-  const cp = start({ quiet: true })
+    t.test('yaml', function (t) {
+      const cp = start({ args: strategy })
 
-  cp.stderr.on('data', function (chunk) {
-    t.equal(chunk, '-- fatal: No versions of strip-lines matching filter: 123.123.123\n')
-    stderr = true
-  })
-  processStdout(cp, function (code, lines) {
-    t.equal(code, 1, 'should exit with code 1')
-    t.equal(stderr, true, 'should output info on STDERR')
-    t.equal(lines.length, 0, 'should not run any commands')
-    t.end()
-  })
-})
+      processStdout(cp, function (code, lines) {
+        t.equal(code, 0)
+        // TODO: Remove tap16 check when Node.js 14 support is dropped
+        t[TAP16 ? 'strictSame' : 'matchOnlyStrict'](lines, [
+          'expire-array@1.1.0: base64-emoji@2.0.0',
+          'expire-array@1.0.0: base64-emoji@2.0.0',
+          'expire-array@1.1.0: base64-emoji@1.0.0',
+          'expire-array@1.0.0: base64-emoji@1.0.0',
+          '//3', // after-all-results@2.0.0, c=3
+          '1/2/', // after-all-results@2.0.0, a=1 b=2
+          '//4', // after-all-results@2.0.0, c=4
+          '1/2/4', // after-all-results@2.0.0, a=1 b=2 c=4
+          '//3', // isobj@1.0.0, c=3
+          '1/2/', // isobj@1.0.0, a=1 b=2
+          'throttling-b', // throttling@1.0.1
+          'throttling-a', // throttling@1.0.2
+          'preinstall', 'pretest', 'b2f-a', 'posttest', 'pretest', 'b2f-b', 'posttest', // b2f@1.0.0
+          '1.0.0', // 27mhz@1.0.1 peerDependency
+          'patterns-a', 'patterns-b', // patterns@1.0.2
+          'patterns-a', 'patterns-b', // patterns@0.0.1
+          'roundround-a', // roundround@0.2.0
+          'roundround-a' // roundround@0.1.0
+        ])
+        t.end()
+      })
+    })
 
-t.test('custom registry using yaml registry property', function (t) {
-  withMockRegistry({ cwd: './test/registry' }, function (path) {
-    t.equal(path, '/is-it-weekend')
-    t.end()
-  })
-})
+    t.test('node version', function (t) {
+      const range = '20.x || 21.x'
+      const active = semver.satisfies(process.version, range)
 
-t.test('custom registry using command line argument', function (t) {
-  withMockRegistry({
-    cwd: './test/registry',
-    args: '--registry=http://localhost:3001/foo/'
-  }, function (path) {
-    t.equal(path, '/foo/is-it-weekend')
-    t.end()
-  })
-})
+      t.plan(active ? 2 : 1)
 
-t.test('versions object', function (t) {
-  const expected = [
-    ...match('include: ~1.2.0', ['1.2.0', '1.2.1']),
-    ...match('include: ~1.2.0, mode: all', ['1.2.0', '1.2.1']),
-    ...match('include: ~1.0.0, exclude: 1.0.1 || 1.0.2', ['1.0.0', '1.0.3']),
-    ...match('include: <=1.4.2, mode: latest-majors', ['0.0.0', '1.4.2']),
-    ...match('include: <=1.4.2, mode: latest-minors', ['0.0.0', '1.0.3', '1.1.0', '1.2.1', '1.3.1', '1.4.2']),
-    ...match('include: <=1.4.2, mode: max-2', ['0.0.0', '1.4.2']),
-    ...match('include: <=1.4.2, mode: max-2-evenly', ['0.0.0', '1.4.2']),
-    ...match('include: <=1.4.2, mode: max-5-evenly', ['0.0.0', '1.0.1', '1.2.0', '1.4.0', '1.4.2']),
-    ...matchSemver('include: <=1.4.2, mode: max-2-random', 2, '<=1.4.2'),
-    ...match('include: <=1.4.2, mode: max-2-latest', ['1.4.1', '1.4.2']),
-    ...match('include: <=1.4.2, mode: max-2-popular', ['1.4.2', '1.4.1'])
-  ].reverse()
+      process.chdir('./test/node-version')
+      const cp = start({ args: strategy })
 
-  process.chdir('./test/versions-object')
-  const cp = start()
+      processStdout(cp, function (code, lines) {
+        t.equal(code, 0)
+        lines.forEach(function (line) {
+          if (!active) t.fail('this node version should not produce any output')
+          t.ok(semver.satisfies(line, range))
+        })
+      })
+    })
 
-  processStdout(cp, function (code, lines) {
-    t.equal(code, 0)
-    expected.forEach(function (expect, index) {
-      switch (typeof expect) {
-        case 'string':
-          t.equal(lines[index], expect)
-          break
-        case 'function':
-          expect(t, lines[index])
-          break
-        default:
-          throw new Error(`Unknown type: ${typeof expect}`)
+    t.test('missing "versions" property', function (t) {
+      process.chdir('./test/missing-versions')
+      let found = false
+      const cp = start({ args: strategy, quiet: true })
+      cp.stderr.on('data', function (chunk) {
+        if (!found && /Error: Missing "versions" property for 27mhz/.test(chunk)) {
+          found = true
+        }
+      })
+      cp.on('close', function (code) {
+        t.equal(code, 1)
+        t.ok(found)
+        t.end()
+      })
+    })
+
+    t.test('array of test cases', function (t) {
+      const expected = ['2.0.1', '2.0.0']
+      t.plan(3)
+
+      process.chdir('./test/array')
+      const cp = start({ args: strategy })
+
+      processStdout(cp, function (code, lines) {
+        t.equal(code, 0)
+        lines.forEach(function (line) {
+          t.equal(line, expected.shift())
+        })
+      })
+    })
+
+    t.test('no matching versions', function (t) {
+      let stderr = false
+
+      process.chdir('./test/no-matching-versions')
+      const cp = start({ args: strategy, quiet: true })
+
+      cp.stderr.on('data', function (chunk) {
+        t.equal(chunk, '-- fatal: No versions of strip-lines matching filter: 123.123.123\n')
+        stderr = true
+      })
+      processStdout(cp, function (code, lines) {
+        t.equal(code, 1, 'should exit with code 1')
+        t.equal(stderr, true, 'should output info on STDERR')
+        t.equal(lines.length, 0, 'should not run any commands')
+        t.end()
+      })
+    })
+
+    t.test('custom registry using yaml registry property', function (t) {
+      withMockRegistry({ cwd: './test/registry', args: strategy }, function (path) {
+        t.equal(path, '/is-it-weekend')
+        t.end()
+      })
+    })
+
+    t.test('custom registry using command line argument', function (t) {
+      withMockRegistry({
+        cwd: './test/registry',
+        args: `${strategy} --registry=http://localhost:3001/foo/`
+      }, function (path) {
+        t.equal(path, '/foo/is-it-weekend')
+        t.end()
+      })
+    })
+
+    t.test('versions object', function (t) {
+      const expected = [
+        ...match('include: ~1.2.0', ['1.2.0', '1.2.1']),
+        ...match('include: ~1.2.0, mode: all', ['1.2.0', '1.2.1']),
+        ...match('include: ~1.0.0, exclude: 1.0.1 || 1.0.2', ['1.0.0', '1.0.3']),
+        ...match('include: <=1.4.2, mode: latest-majors', ['0.0.0', '1.4.2']),
+        ...match('include: <=1.4.2, mode: latest-minors', ['0.0.0', '1.0.3', '1.1.0', '1.2.1', '1.3.1', '1.4.2']),
+        ...match('include: <=1.4.2, mode: max-2', ['0.0.0', '1.4.2']),
+        ...match('include: <=1.4.2, mode: max-2-evenly', ['0.0.0', '1.4.2']),
+        ...match('include: <=1.4.2, mode: max-5-evenly', ['0.0.0', '1.0.1', '1.2.0', '1.4.0', '1.4.2']),
+        ...matchSemver('include: <=1.4.2, mode: max-2-random', 2, '<=1.4.2'),
+        ...match('include: <=1.4.2, mode: max-2-latest', ['1.4.1', '1.4.2']),
+        ...match('include: <=1.4.2, mode: max-2-popular', ['1.4.2', '1.4.1'])
+      ].reverse()
+
+      process.chdir('./test/versions-object')
+      const cp = start({ args: strategy })
+
+      processStdout(cp, function (code, lines) {
+        t.equal(code, 0)
+        expected.forEach(function (expect, index) {
+          switch (typeof expect) {
+            case 'string':
+              t.equal(lines[index], expect)
+              break
+            case 'function':
+              expect(t, lines[index])
+              break
+            default:
+              throw new Error(`Unknown type: ${typeof expect}`)
+          }
+        })
+        t.end()
+      })
+
+      function match (prefix, versions) {
+        return versions.map((v) => `${prefix}, gunzip-maybe@${v}`)
+      }
+
+      function matchSemver (prefix, total, expectedRange) {
+        const regex = new RegExp(`^${prefix}, gunzip-maybe@(.+)$`)
+        return new Array(total).fill((t, line) => {
+          const result = line.match(regex)
+          if (!result) return t.fail(`"${line}" doesn't match regex ${regex.toString()}`)
+          t.ok(semver.satisfies(result[1], expectedRange))
+        })
       }
     })
-    t.end()
   })
-
-  function match (prefix, versions) {
-    return versions.map((v) => `${prefix}, gunzip-maybe@${v}`)
-  }
-
-  function matchSemver (prefix, total, expectedRange) {
-    const regex = new RegExp(`^${prefix}, gunzip-maybe@(.+)$`)
-    return new Array(total).fill((t, line) => {
-      const result = line.match(regex)
-      if (!result) return t.fail(`"${line}" doesn't match regex ${regex.toString()}`)
-      t.ok(semver.satisfies(result[1], expectedRange))
-    })
-  }
 })
 
 function start ({ args = '', quiet = false } = {}) {


### PR DESCRIPTION
To speed up testing all instrumentations against all versions of all libraries, https://github.com/open-telemetry/opentelemetry-js-contrib/ attempted to run the tasks in parallel. Because it's a monorepo, and because test-all-versions operates on the entire workspace, this produced errors with missing dependencies.

This patch attempts to solve this by installing the packages tav needs to install into a separate synthetic package using [install-strategy=linked](https://docs.npmjs.com/cli/v9/commands/npm-install#install-strategy), and then linking the results into the `node_modules` of the original project.

What do you think of this, @watson?
The change could be modified to put this under experimental flag or a strategy arg to make the release less painful if it's accepted.